### PR TITLE
Disable transcript overlay

### DIFF
--- a/js/chat/chat-manager.js
+++ b/js/chat/chat-manager.js
@@ -1,7 +1,8 @@
 export class ChatManager {
     constructor() {
         this.chatContainer = document.getElementById('chatHistory');
-        this.transcriptDisplay = document.getElementById('transcriptDisplay');
+        // Disable overlay transcript display
+        this.transcriptDisplay = null;
         this.currentStreamingMessage = null;
         this.lastUserMessageType = null; // 'text' or 'audio'
         this.currentTranscript = ''; // Add this to store accumulated transcript


### PR DESCRIPTION
## Summary
- disable transcript overlay by setting `transcriptDisplay` to `null`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687169b02f5c832cbf8ca70a580153d7