### PR TITLE
Fix overlay transcripts

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -6,6 +6,7 @@ import { ToolManager } from './tools/tool-manager.js';
 import { ChatManager } from './chat/chat-manager.js';
 
 import { setupEventListeners } from './dom/events.js';
+import elements from './dom/elements.js';
 
 const url = getWebsocketUrl();
 const config = getConfig();
@@ -15,6 +16,7 @@ const toolManager = new ToolManager();
 toolManager.registerTool('googleSearch', new GoogleSearchTool());
 
 const chatManager = new ChatManager();
+chatManager.transcriptDisplay = elements.transcriptDisplay;
 
 const geminiAgent = new GeminiAgent({
     url,


### PR DESCRIPTION
## Summary
- wire up `transcriptDisplay` so transcript overlay appears during streaming

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716e1da044832ca55539552043ef4e