### PR TITLE
Enable console logging of transcripts

### DIFF
--- a/js/main/agent.js
+++ b/js/main/agent.js
@@ -320,7 +320,7 @@ export class GeminiAgent{
         // Just log transcription to console for now
         this.modelTranscriber.on('transcription', (transcript) => {
             this.emit('transcription', transcript);
-            console.debug('Model speech transcription:', transcript);
+            console.log('Model speech transcription:', transcript);
         });
 
         // Connect to Deepgram and execute promise
@@ -356,7 +356,7 @@ export class GeminiAgent{
         // Handle user transcription events
         this.userTranscriber.on('transcription', (transcript) => {
             this.emit('user_transcription', transcript);
-            console.debug('User speech transcription:', transcript);
+            console.log('User speech transcription:', transcript);
         });
 
         // Connect to Deepgram and execute promise

--- a/js/script.js
+++ b/js/script.js
@@ -29,6 +29,12 @@ const geminiAgent = new GeminiAgent({
 // Handle chat-related events
 geminiAgent.on('transcription', (transcript) => {
     chatManager.updateStreamingMessage(transcript);
+    console.log('Transcript:', transcript);
+});
+
+// Log user's speech transcript
+geminiAgent.on('user_transcription', (transcript) => {
+    console.log('User transcript:', transcript);
 });
 
 geminiAgent.on('text_sent', (text) => {


### PR DESCRIPTION
## Summary
- show model speech transcriptions in console
- show user speech transcriptions in console
- log transcripts in `script.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687171c63ed8832c952e0ae8b7625a22